### PR TITLE
HTTP REST API for Protoplaster server mode

### DIFF
--- a/.github/docs-template/requirements.txt
+++ b/.github/docs-template/requirements.txt
@@ -1,2 +1,3 @@
 https://github.com/antmicro/antmicro-sphinx-utils/archive/main.zip
 pydantic==2.4.2 #2.5.0 causes AttributeError during sphinx execution
+sphinxcontrib-httpdomain

--- a/.github/docs-template/source/api.rst
+++ b/.github/docs-template/source/api.rst
@@ -1,0 +1,32 @@
+
+Protoplaster Server API Reference
+---------------------------------
+
+Error Handling
+~~~~~~~~~~~~~~
+
+Should an error occur during the handling of an API request, either because of incorrect request data or other endpoint-specific scenarios, the server will return an error structure containing a user-friendly description of the error.
+An example error response is shown below:
+
+.. sourcecode:: json
+
+   {
+      "error": "test start failed"
+   }
+
+
+Configs API
+~~~~~~~~~~~
+
+.. autoflask:: protoplaster.protoplaster:create_docs_app()
+   :modules: protoplaster.api.v1.configs
+   :undoc-static:
+   :order: path
+
+Test Runs API
+~~~~~~~~~~~~~
+
+.. autoflask:: protoplaster.protoplaster:create_docs_app()
+   :modules: protoplaster.api.v1.test_runs
+   :undoc-static:
+   :order: path

--- a/.github/docs-template/source/conf.py
+++ b/.github/docs-template/source/conf.py
@@ -37,6 +37,8 @@ numfig = True
 
 # If you need to add extensions just add to those lists
 extensions = default_extensions
+extensions.append('sphinxcontrib.autohttp.flask')
+extensions.append('sphinxcontrib.autohttp.flaskqref')
 myst_enable_extensions = default_myst_enable_extensions
 myst_fence_as_directive = default_myst_fence_as_directive
 

--- a/.github/docs-template/source/index.md
+++ b/.github/docs-template/source/index.md
@@ -4,6 +4,7 @@
 :maxdepth: 2
 
 introduction
+api
 readme
 protoplaster
 report

--- a/.github/docs-template/source/introduction.md
+++ b/.github/docs-template/source/introduction.md
@@ -2,7 +2,9 @@
 
 This documentation serves as an example of how individual projects documentation can look like.
 
-The second chapter contains information from the README file.
+The second chapter contains reference of remote API when running Protoplaster in server mode.
+
+The third chapter contains information from the README file.
 
 The last chapter is generated from the sample ``test.yml`` file which can be found in the README.
 Its purpose is to demonstrate the documentation generated to describe test procedures used in a project.

--- a/.github/scripts/latex.sh
+++ b/.github/scripts/latex.sh
@@ -2,12 +2,16 @@
 
 set -e
 
+apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends git
+
 cd $(dirname $0)/../../docs
 
 python3 -m venv ./venv
 . ./venv/bin/activate
 
 pip3 install -r requirements.txt
+pip3 install ../
 
 cd build/latex
 LATEXMKOPTS='-interaction=nonstopmode' make

--- a/.github/scripts/sphinx.sh
+++ b/.github/scripts/sphinx.sh
@@ -8,6 +8,7 @@ python3 -m venv ./venv
 . ./venv/bin/activate
 
 pip3 install -r requirements.txt
+pip3 install ../
 
 make html latex
 

--- a/protoplaster/api/v1/__init__.py
+++ b/protoplaster/api/v1/__init__.py
@@ -1,0 +1,10 @@
+from flask import Blueprint
+
+import protoplaster.api.v1.configs
+
+
+def create_routes() -> Blueprint:
+    api_routes: Blueprint = Blueprint("protoplaster-api-v1", __name__)
+    api_routes.register_blueprint(
+        protoplaster.api.v1.configs.configs_blueprint)
+    return api_routes

--- a/protoplaster/api/v1/__init__.py
+++ b/protoplaster/api/v1/__init__.py
@@ -1,10 +1,13 @@
 from flask import Blueprint
 
 import protoplaster.api.v1.configs
+import protoplaster.api.v1.test_runs
 
 
 def create_routes() -> Blueprint:
     api_routes: Blueprint = Blueprint("protoplaster-api-v1", __name__)
     api_routes.register_blueprint(
         protoplaster.api.v1.configs.configs_blueprint)
+    api_routes.register_blueprint(
+        protoplaster.api.v1.test_runs.test_runs_blueprint)
     return api_routes

--- a/protoplaster/api/v1/configs.py
+++ b/protoplaster/api/v1/configs.py
@@ -1,0 +1,163 @@
+from flask import Blueprint
+
+configs_blueprint: Blueprint = Blueprint("protoplaster-configs", __name__)
+
+
+@configs_blueprint.route("/api/v1/configs")
+def fetch_configs():
+    """Fetch a list of configs
+
+    :status 200: no error
+
+    :>jsonarr string created: UTC datetime of config upload (RFC822)
+    :>jsonarr string name: config name
+
+    **Example Request**
+
+    .. sourcecode:: http
+
+        GET /api/v1/configs HTTP/1.1
+        Accept: application/json, text/javascript
+
+
+    **Example Response**
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+          {
+            "name": "sample_config.yaml",
+            "created": "Mon, 25 Aug 2025 16:58:35 +0200",
+          }
+        ]
+    """  # noqa: E501
+    #TODO: Add implementation
+    return {}, 200
+
+
+@configs_blueprint.route("/api/v1/configs", methods=["POST"])
+def upload_config(scopes: list[str] = []):
+    """Upload a test config
+
+    :form file: yaml file with the test config
+
+    :status 200: no error, config was uploaded
+    :status 400: file was not provided
+
+    **Example Request**
+
+    .. sourcecode:: http
+
+        POST /api/v1/configs HTTP/1.1
+        Accept: */*
+        Content-Length: 4194738
+        Content-Type: multipart/form-data; boundary=------------------------0f8f9642db3a513e
+
+        --------------------------0f8f9642db3a513e
+        Content-Disposition: form-data; name="file"; filename="config.yaml"
+        Content-Type: application/octet-stream
+
+        <file contents>
+        --------------------------0f8f9642db3a513e--
+
+
+    **Example Response**
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+    """  # noqa: E501
+    #TODO: Add implementation
+    return {}, 200
+
+
+@configs_blueprint.route("/api/v1/configs/<string:config_name>")
+def fetch_one_config():
+    """Fetch information about a config
+
+    :status 200: no error
+    :status 404: config does not exist
+
+    :>json string created: UTC datetime of config upload (RFC822)
+    :>json string config_name: config name
+
+    **Example Request**
+
+    .. sourcecode:: http
+
+        GET /api/v1/configs/sample_config.yaml HTTP/1.1
+        Accept: application/json, text/javascript
+
+    **Example Response**
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {
+          "name": "sample_config.yaml",
+          "created": "Mon, 25 Aug 2025 16:58:35 +0200",
+        }
+    """  # noqa: E501
+    #TODO: Add implementation
+    return {}, 200
+
+
+@configs_blueprint.route("/api/v1/configs/<string:config_name>/file")
+def fetch_config_file():
+    """Fetch a config file
+
+    :status 200: no error
+    :status 404: config does not exist
+
+    :>file text/yaml: YAML config file
+
+    **Example Request**
+
+    .. sourcecode:: http
+
+        GET /api/v1/configs/sample_config.yaml/file HTTP/1.1
+
+    **Example Response**
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: text/yaml
+        Content-Disposition: attachment; filename="sample_config.yaml"
+
+        base:
+          network:
+            - interface: enp14s0
+    """  # noqa: E501
+    #TODO: Add implementation
+    return {}, 200
+
+
+@configs_blueprint.route("/api/v1/configs/<string:name>", methods=["DELETE"])
+def delete_config(scopes: list[str] = []):
+    """Remove a test config
+
+    :param name: filename of the test config
+
+    :status 200: no error, config was removed
+    :status 404: file was not found
+
+    **Example Request**
+
+    .. sourcecode:: http
+
+        DELETE /api/v1/configs/sample_config.yaml HTTP/1.1
+
+    **Example Response**
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+    """  # noqa: E501
+    #TODO: Add implementation
+    return {}, 200

--- a/protoplaster/api/v1/test_runs.py
+++ b/protoplaster/api/v1/test_runs.py
@@ -1,0 +1,196 @@
+from flask import Blueprint
+
+test_runs_blueprint: Blueprint = Blueprint("protoplaster-test-runs", __name__)
+
+
+@test_runs_blueprint.route("/api/v1/test-runs")
+def fetch_test_runs():
+    """Fetch a list of test runs
+
+    :status 200: no error
+
+    :>jsonarr integer run_id: run id
+    :>jsonarr string config_name: name of config for this test run
+    :>jsonarr string test_suite_name: name of the test suite for this test run
+    :>jsonarr string created: UTC datetime of test run start (RFC822)
+    :>jsonarr string completed: UTC completion time (RFC822) 
+    :>jsonarr string status: test run status, one of:
+        * pending   - accepted but not started
+        * running   - currently executing
+        * finished  - completed successfully
+        * failed    - error during execution
+        * aborted   - stopped by user or system
+    :>jsonarr dict[str, str] metadata: optional test run metadata (key/value pairs)
+
+    **Example Request**
+
+    .. sourcecode:: http
+
+        GET /api/v1/test-runs HTTP/1.1
+        Accept: application/json, text/javascript
+
+
+    **Example Response**
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+          {
+            "run_id": 1,
+            "config_name": "config1.yaml"
+            "test_suite_name": "simple-test"
+            "status": "finished",
+            "created": "Mon, 25 Aug 2025 15:56:35 +0200",
+            "metadata": {
+              "bsp-sha256": "a5603553e0eaad133719dc19b57c96e811a72af5329e120310f96b4fdc891732"
+            }
+          },
+          {
+            "run_id": 2,
+            "config_name": "config2.yaml"
+            "test_suite_name": "complex-test"
+            "status": "running",
+            "created": "Mon, 25 Aug 2025 16:58:35 +0200",
+            "metadata": {}
+          }
+        ]
+    """  # noqa: E501
+    #TODO: Add implementation
+    return {}, 200
+
+
+@test_runs_blueprint.route("/api/v1/test-runs", methods=["POST"])
+def trigger_test_run(scopes: list[str] = []):
+    """Trigger a test run
+
+
+    :status 200: no error, test run was triggered
+    :status 400: file was not provided
+
+    :<json string config_name: name of config for this test run
+    :<json string test_suite_name: name of the test suite for this test run
+
+    **Example Request**
+
+    .. sourcecode:: http
+
+        POST /api/v1/test-runs/ HTTP/1.1
+        Content-Type: application/json
+        Accept: application/json, text/javascript
+
+        {
+          "config_name": "config1.yaml",
+          "test_suite_name": "simple-test"
+        }
+
+    **Example Response**
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+    """  # noqa: E501
+    #TODO: Add implementation
+    return {}, 200
+
+
+@test_runs_blueprint.route("/api/v1/test-runs/<int:identifier>")
+def fetch_one_test_run(identifier: int):
+    """Fetch information about a test run
+
+    :param identifier: test run identifier
+    :status 200: no error
+    :status 404: test run does not exist
+
+    :>json integer id: test run identifier
+    :>json string created: UTC creation time (RFC822)
+    :>json string completed: UTC completion time (RFC822)
+    :>json string status: test run status, one of:
+        * pending   - accepted but not started
+        * running   - currently executing
+        * finished  - completed successfully
+        * failed    - error during execution
+        * aborted   - stopped by user or system
+    :>json dict[str, str] metadata: optional test run metadata (key/value pairs)
+
+    **Example Request**
+
+    .. sourcecode:: http
+
+        GET /api/v1/test-runs/1 HTTP/1.1
+
+    **Example Response**
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {
+          "run_id": 1,
+          "config_name": "config1.yaml"
+          "status": "finished",
+          "created": "Mon, 25 Aug 2025 15:56:35 +0200",
+          "metadata": {
+            "bsp-sha256": "a5603553e0eaad133719dc19b57c96e811a72af5329e120310f96b4fdc891732"
+          }
+        }
+    """  # noqa: E501
+    #TODO: Add implementation
+    return {}, 200
+
+
+@test_runs_blueprint.route("/api/v1/test-runs/<int:identifier>",
+                           methods=["DELETE"])
+def delete_test_run(identifier: int):
+    """Cancel a test run
+
+    :param identifier: test run identifier
+    :status 200: no error
+    :status 400: test run not in progress
+    :status 404: test run does not exist
+
+    **Example Request**
+
+    .. sourcecode:: http
+
+        DELETE /api/v1/test-runs/1 HTTP/1.1
+
+    **Example Response**
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+    """  # noqa: E501
+    #TODO: Add implementation
+    return {}, 200
+
+
+@test_runs_blueprint.route("/api/v1/test-runs/<int:identifier>/report")
+def fetch_test_run_report(identifier: int):
+    """Fetch test run report
+
+    :param identifier: test run identifier
+    :status 200: no error
+    :status 404: test run not completed or does not exist
+
+    :>file text/csv: CSV file containing the full test report
+
+    **Example request**
+
+        GET /api/v1/runs/1/report HTTP/1.1
+
+    **Example response**
+
+        HTTP/1.1 200 OK
+        Content-Type: text/csv
+        Content-Disposition: attachment; filename="report-run-12345.csv"
+
+        device name,test name,module,duration,message,status
+        enp14s0,exist,test.py::TestNetwork::test_exist,0.0007359918672591448,,passed
+
+    """  # noqa: E501
+    #TODO: Add implementation
+    return {}, 200

--- a/protoplaster/protoplaster.py
+++ b/protoplaster/protoplaster.py
@@ -42,6 +42,18 @@ tests_paths = {
 app = Flask(__name__)
 
 
+def create_docs_app() -> Flask:
+    """Create an app that can be used for building the docs
+
+    This only registers the available API routes, this cannot be used to run
+    the server! Used for dynamically building the API reference chapter in
+    the documentation.
+    """
+    app = Flask(__name__)
+    app.register_blueprint(protoplaster.api.v1.create_routes())
+    return app
+
+
 init()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Jinja2==3.1.2
 MarkupSafe==2.1.1
 pyrav4l2 @ git+https://github.com/antmicro/pyrav4l2.git@3c071a7
 pyudev==0.24.1
+Flask==3.1.2


### PR DESCRIPTION
This PR contains a proposal of HTTP REST API for remote control of test execution. The goal is to enable: configuration upload, test triggering, progress monitoring and retrieval of test reports.

## API Overview

* Configuration
  * `GET /api/v1/configs` - list available configuration files
  * `POST /api/v1/configs` - upload new/overwrite existing configuration file
  * `GET /api/v1/configs/(string: config_name)` - fetch information about a single configuration file
  * `DELETE /api/v1/configs/(string: config_name)` - remove a configuration file

* Test runs
  * `POST /api/v1/test-runs` - trigger a new test run based on a selected configuration (can be optionally modified using the `overrides` field)
  * `GET /api/v1/test-runs` - list all test runs
  * `GET /api/v1/test-runs/(int: identifier)` - fetch information about a single test run
  * `GET /api/v1/test-runs/(int: identifier)/report` - download the test report from a completed test run

## Test run states

Test runs progress through a set of states:
* `pending` - accepted but not started
* `running` - currently executing
* `finished` - completed successfully
* `failed` - error during execution
* `aborted` - stopped by user or system

## Documentation

The API is described in detail in docstrings for each endpoint, documentation generated from the docstrings is available at: https://antmicro.github.io/protoplaster-docs-preview/api.html# (note that this is a temporary URL used for this PR only, it will be merged with the main documentation once this PR is merged).

## Discussion points

* The current approach to config files is kept with this API proposal. The meaning is that configuration files store a number of tests (i.e. a single config is more of a full test suite). The API currently allows starting full "suites" only (either with stock config or with a modified config). Question: Should there be a way of triggering a single test from the selected configuration?
* The proposed overrides mechanism allows the user to override all the parts of the configuration file. This means that a similar mechanism could be used to trigger arbitrary test variations without any config file on the device - would this be useful? If so, should both configs/arbitrary runs be available or should we prefer one over the other?
* We assume no proper database will be used, everything should operate on the available files on the device.