### PR TITLE
Allow support for pyyaml > 5.3.1 and colorama > 0.3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 myst_parser==4.0.1
 pytest==7.4.3
 pytest-instafail==0.5.0
-pyyaml==5.3.1
+pyyaml>=5.3.1
 smbus2==0.3.0
 spidev==3.8; python_version > '3.11.10'
-colorama==0.3.9
+colorama>=0.3.9
 Jinja2==3.1.2
 MarkupSafe==2.1.1
 pyrav4l2 @ https://github.com/antmicro/pyrav4l2/archive/3c071a7494b6b67263c4dddb87b47025338fd960.zip


### PR DESCRIPTION
Description: To extend compatibility to other projects. Haven't tested this change with a variety of versions, but I assume it should be okay.